### PR TITLE
 Enable separate block device for application code

### DIFF
--- a/firerunner/Cargo.lock
+++ b/firerunner/Cargo.lock
@@ -14,8 +14,8 @@ version = "0.1.0"
 dependencies = [
  "arch_gen 0.1.0",
  "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kvm 0.1.0",
  "kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvm-ioctls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory_model 0.1.0",
 ]
@@ -77,8 +77,8 @@ dependencies = [
 name = "cpuid"
 version = "0.1.0"
 dependencies = [
+ "kvm 0.1.0",
  "kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvm-ioctls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -166,18 +166,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "kvm-bindings"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "kvm-ioctls"
+name = "kvm"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sys_util 0.1.0",
 ]
+
+[[package]]
+name = "kvm-bindings"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
@@ -437,8 +437,8 @@ dependencies = [
  "fc_util 0.1.0",
  "futures 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel 0.1.0",
+ "kvm 0.1.0",
  "kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "kvm-ioctls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0",
  "memory_model 0.1.0",
@@ -486,7 +486,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum json-patch 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a89946fbd8692b4e7ace4c0432431dfbc4075f8a3bdcd3695de5ad11b26a83e3"
 "checksum kvm-bindings 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c223e8703d2eb76d990c5f58e29c85b0f6f50e24b823babde927948e7c71fc03"
-"checksum kvm-ioctls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f87b0c7322658f94e9fcf661146c9761a487813f3154e6a67a24fc59c68f5306"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"

--- a/firerunner/src/main.rs
+++ b/firerunner/src/main.rs
@@ -57,7 +57,7 @@ fn main() {
                 .long("appfs")
                 .value_name("APPFS")
                 .takes_value(true)
-                .required(true)
+                .required(false)
                 .help("Path to the root file system")
         )
         .arg(
@@ -86,7 +86,7 @@ fn main() {
 
     let kernel = cmd_arguments.value_of("kernel").unwrap().to_string();
     let rootfs = cmd_arguments.value_of("rootfs").unwrap().to_string();
-    let appfs = cmd_arguments.value_of("appfs").unwrap().to_string();
+    let appfs = cmd_arguments.value_of("appfs");
     let cmd_line = cmd_arguments.value_of("command line").unwrap().to_string();
 
     // It's safe to unwrap here because clap's been provided with a default value
@@ -140,15 +140,17 @@ fn main() {
         rate_limiter: None,
     };
     println!("{:?}", vmm.insert_block_device(block_config).expect("Rootfs"));
-    let block_config = BlockDeviceConfig {
-        drive_id: String::from("appfs"),
-        path_on_host: PathBuf::from(appfs),
-        is_root_device: false,
-        is_read_only: true,
-        partuuid: None,
-        rate_limiter: None,
-    };
-    println!("AppBlk {:?}", vmm.insert_block_device(block_config).expect("AppBlk"));
+    if let Some(appfs) = appfs {
+        let block_config = BlockDeviceConfig {
+            drive_id: String::from("appfs"),
+            path_on_host: PathBuf::from(appfs),
+            is_root_device: false,
+            is_read_only: true,
+            partuuid: None,
+            rate_limiter: None,
+        };
+        println!("AppBlk {:?}", vmm.insert_block_device(block_config).expect("AppBlk"));
+    }
 
     println!("Starting {:?}", vmm.start_instance().expect("Start"));
     println!("State {:?}", shared_info.read().expect("SharedInfo").state);

--- a/firerunner/src/main.rs
+++ b/firerunner/src/main.rs
@@ -52,6 +52,15 @@ fn main() {
                 .help("Path to the root file system")
         )
         .arg(
+            Arg::with_name("appfs")
+                .long("a")
+                .long("appfs")
+                .value_name("APPFS")
+                .takes_value(true)
+                .required(true)
+                .help("Path to the root file system")
+        )
+        .arg(
             Arg::with_name("id")
                 .long("id")
                 .help("MicroVM unique identifier")
@@ -77,6 +86,7 @@ fn main() {
 
     let kernel = cmd_arguments.value_of("kernel").unwrap().to_string();
     let rootfs = cmd_arguments.value_of("rootfs").unwrap().to_string();
+    let appfs = cmd_arguments.value_of("appfs").unwrap().to_string();
     let cmd_line = cmd_arguments.value_of("command line").unwrap().to_string();
 
     // It's safe to unwrap here because clap's been provided with a default value
@@ -112,29 +122,37 @@ fn main() {
         sender,
         event_fd,
     };
-    let config = vmm.get_configuration().unwrap();
 
-    println!("Configuration: {:?}", config);
+    println!("Configuration: {:?}", vmm.get_configuration().expect("config"));
 
     let boot_config = BootSourceConfig {
         kernel_image_path: kernel,
         boot_args: Some(cmd_line),
     };
-    println!("{:?}", vmm.set_boot_source(boot_config).unwrap());
+    println!("{:?}", vmm.set_boot_source(boot_config).expect("bootsource"));
 
     let block_config = BlockDeviceConfig {
         drive_id: String::from("rootfs"),
         path_on_host: PathBuf::from(rootfs),
         is_root_device: true,
-        is_read_only: false,
+        is_read_only: true,
         partuuid: None,
         rate_limiter: None,
     };
-    println!("{:?}", vmm.insert_block_device(block_config).unwrap());
+    println!("{:?}", vmm.insert_block_device(block_config).expect("Rootfs"));
+    let block_config = BlockDeviceConfig {
+        drive_id: String::from("appfs"),
+        path_on_host: PathBuf::from(appfs),
+        is_root_device: false,
+        is_read_only: true,
+        partuuid: None,
+        rate_limiter: None,
+    };
+    println!("AppBlk {:?}", vmm.insert_block_device(block_config).expect("AppBlk"));
 
-    println!("{:?}", vmm.start_instance().unwrap());
-    println!("{:?}", shared_info.read().unwrap().state);
-    vmm_thread_handle.join().unwrap();
+    println!("Starting {:?}", vmm.start_instance().expect("Start"));
+    println!("State {:?}", shared_info.read().expect("SharedInfo").state);
+    vmm_thread_handle.join().expect("Join");
 }
 
 struct VmmWrapper {


### PR DESCRIPTION
Allows a Firerunner user to specify a separate block device containing
their application code, in addition to the root file system.

Both rootfs and appfs are exposed as read-only block devices