### PR TITLE
Add scripts to generate runtime-specific root file systems

### DIFF
--- a/images/mk_rtimage.sh
+++ b/images/mk_rtimage.sh
@@ -1,0 +1,61 @@
+#/usr/bin/env bash
+
+## Creates an alpine-linux based rootfs for a particular runtime.  ## All
+## runtimes share a common prelude and postscript for initialization and are
+## specialized by scripts defined in the `runtimes/` subdirectory (typically
+## just an `apk` command to install the relevant runtime binaries and libraries).
+##
+## Usage
+## -----
+##
+## $ ./mk_rtimage.sh RUNTIME OUTPUT_FILE
+##
+## Where RUNTIME is one of the runtimes defined in `runtimes`, without the `.sh`
+## extension, and OUTPUT is the file with the resulting root file system.
+##
+## Running this script requires super user privileges to mount the target file
+## system, but you don't have to run with `sudo`, the script uses `sudo` explicitly.
+
+function print_runtimes() {
+  echo -e "Available runtimes:"
+  for runtime_file in $(ls runtimes/)
+  do
+    echo -e "  * $(basename $runtime_file .sh)"
+  done
+}
+
+## Check command line argument length
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 [RUNTIME] [OUTPUT_FS_IMAGE]"
+  print_runtimes
+  exit 1
+fi
+
+RUNTIME=runtimes/$1.sh
+OUTPUT=$2
+
+if [ ! -f "$RUNTIME" ]; then
+  echo "Runtime \`$1\` not found."
+  print_runtimes
+  exit 1
+fi
+
+## Create a temporary directory to mount the filesystem
+TMPDIR=`mktemp -d`
+
+## Delete the output file if it exists, and create a new one formatted as
+## an EXT4 filesystem.
+rm -f $OUTPUT
+dd if=/dev/zero of=$OUTPUT bs=1M count=500
+mkfs.ext4 $OUTPUT
+
+## Mount the output file in the temporary directory
+sudo mount $OUTPUT $TMPDIR
+
+## Execute the prelude, runtime script and postscript inside an Alpine docker container
+## with the target root file system shared at `/my-rootfs` inside the container.
+cat prelude.sh $RUNTIME.sh postscript.sh | docker run -i --rm -v $TMPDIR:/my-rootfs alpine
+
+## Cleanup
+sudo umount $TMPDIR
+rm -Rf $TMPDIR

--- a/images/postscript.sh
+++ b/images/postscript.sh
@@ -1,0 +1,10 @@
+## Make sure fstab exists and is empty
+cat > /etc/fstab
+
+## Copy all relevant useful directories to /my-rootfs, where the target filesystem is mounted
+for d in bin etc lib root sbin usr home srv; do tar c "$d" | tar x -C /my-rootfs; done
+
+## Create empty directories for remaining folders
+for dir in tmp dev proc run sys var; do mkdir /my-rootfs/${dir}; done
+
+exit

--- a/images/prelude.sh
+++ b/images/prelude.sh
@@ -1,0 +1,25 @@
+apk add openrc util-linux
+
+## Create start script for that mounts the appfs and invokes whatever binary is in /srv/workload
+printf '#!/bin/sh\n
+mount /dev/vdb /srv\n
+exec /srv/workload\n' > /bin/workload
+chmod +x /bin/workload
+
+## Have the start script invoked by openrc/init
+printf '#!/sbin/openrc-run\n
+command="/bin/workload"\n' > /etc/init.d/serverless-workload
+chmod +x /etc/init.d/serverless-workload
+rc-update add serverless-workload default
+
+## Setup console
+ln -s agetty /etc/init.d/agetty.ttyS0
+echo ttyS0 > /etc/securetty
+rc-update add agetty.ttyS0 default
+rc-update add agetty.ttyS0 nonetwork
+
+echo agetty_options=\"-a root\" >> /etc/conf.d/agetty
+
+## Add /dev and /proc file systems to openrc's boot
+rc-update add devfs boot
+rc-update add procfs boot

--- a/images/runtimes/nodejs.sh
+++ b/images/runtimes/nodejs.sh
@@ -1,0 +1,1 @@
+apk add nodejs

--- a/images/runtimes/python2.sh
+++ b/images/runtimes/python2.sh
@@ -1,0 +1,1 @@
+apk add python2 python2-dev

--- a/images/runtimes/python3.sh
+++ b/images/runtimes/python3.sh
@@ -1,0 +1,1 @@
+apk add python3 python3-dev


### PR DESCRIPTION
Adds a (hopefully) simple script to generate a rootfs for a particular runtime. At a high level, it uses the base alpine docker image (the default one from Docker Hub), and runs three scripts inside the container:

  * `prelude.sh` sets up openrc scripts, including creating a generic startup init script that mounts the appfs at `/srv` and executes `/srv/workload`.

  * A runtime specific script found in `runtimes` which generally just installs the runtime using alpine's `apk add`.

  * `postscript.sh` copies files from the docker image into the root file system (mounted temporarily at /my-rootfs)

Appfs images to follow.