### PR TITLE
Update nodejs and python2 wrapper scripts and firerunner's default cmd_line

### DIFF
--- a/firerunner/bins/firerunner/main.rs
+++ b/firerunner/bins/firerunner/main.rs
@@ -33,7 +33,7 @@ fn main() {
                 .value_name("CMD_LINE")
                 .takes_value(true)
                 .required(false)
-                .default_value("quiet console=ttyS0 reboot=k panic=1 pci=off")
+                .default_value("quiet console=none reboot=k panic=1 pci=off")
                 .help("Command line to pass to the kernel")
         )
         .arg(

--- a/images/prelude.sh
+++ b/images/prelude.sh
@@ -6,7 +6,7 @@ cp /common/outl /usr/bin/outl
 ## Create start script for that mounts the appfs and invokes whatever binary is in /srv/workload
 printf '#!/bin/sh\n
 stty -F /dev/ttyS1 -echo >/dev/null\n
-exec /bin/runtime-workload >/dev/ttyS1\n' > /bin/workload
+exec /bin/runtime-workload\n' > /bin/workload
 chmod +x /bin/workload
 
 ## Have the start script invoked by openrc/init

--- a/images/runtimes/nodejs/workload.js
+++ b/images/runtimes/nodejs/workload.js
@@ -1,5 +1,4 @@
 const { execSync, exec } = require("child_process");
-const process = require("process");
 const readline = require("readline");
 const fs = require("fs");
 
@@ -19,6 +18,9 @@ rl = readline.createInterface({
     input: fs.createReadStream('/dev/ttyS1'),
     crlfDelay: Infinity
 });
+
+out = fs.createWriteStream('/dev/ttyS1');
+
 // signal Firerunner that we are ready to receive requests
 execSync("outl 126 0x3f0");
 
@@ -29,7 +31,7 @@ rl.on('line', (line) => {
   let req = JSON.parse(line);
   app.handle(req, function(resp) {
     let respJS = JSON.stringify(resp);
-    process.stdout.write(Buffer.from([respJS.length]));
-    process.stdout.write(respJS, "utf8");
+    out.write(Buffer.from([respJS.length]));
+    out.write(respJS, "utf8");
   });
 });

--- a/images/runtimes/nodejs/workload.js
+++ b/images/runtimes/nodejs/workload.js
@@ -8,15 +8,12 @@ const fs = require("fs");
 // and that other cpus writes to the port before us
 // since as of now snapshots are created offline, we are fine
 const cpu_count = require("os").cpus().length;
-for (var i = 0; i < cpu_count; i++) {
+for (var i = 1; i < cpu_count; i++) {
     exec(`taskset -c ${i} outl 124 0x3f0`);
 }
 execSync("taskset -c 0 outl 124 0x3f0");
 
 execSync("mount -r /dev/vdb /srv");
-
-module.paths.push("/srv/node_modules");
-const app = require("/srv/workload");
 
 rl = readline.createInterface({
     input: fs.createReadStream('/dev/ttyS1'),
@@ -24,6 +21,9 @@ rl = readline.createInterface({
 });
 // signal Firerunner that we are ready to receive requests
 execSync("outl 126 0x3f0");
+
+module.paths.push("/srv/node_modules");
+const app = require("/srv/workload");
 
 rl.on('line', (line) => {
   let req = JSON.parse(line);

--- a/images/runtimes/python2/workload.py
+++ b/images/runtimes/python2/workload.py
@@ -15,7 +15,7 @@ call('taskset -c 0 outl 124 0x3f0', shell=True)
 
 os.system("mount -r /dev/vdb /srv")
 
-with open('/dev/ttyS1', 'r') as tty:
+with open('/dev/ttyS1', 'r') as tty, open('/dev/ttyS1', 'w') as out:
     # signal firerunner we are ready
     call('outl 126 0x3f0', shell=True)
 
@@ -29,6 +29,6 @@ with open('/dev/ttyS1', 'r') as tty:
 
         responseJson = json.dumps(response)
 
-        sys.stdout.write(struct.pack("@B", len(responseJson)))
-        sys.stdout.write(bytes(responseJson))
-        sys.stdout.flush()
+        out.write(struct.pack("@B", len(responseJson)))
+        out.write(bytes(responseJson))
+        out.flush()

--- a/images/runtimes/python2/workload.py
+++ b/images/runtimes/python2/workload.py
@@ -15,12 +15,13 @@ call('taskset -c 0 outl 124 0x3f0', shell=True)
 
 os.system("mount -r /dev/vdb /srv")
 
-sys.path.append('/srv/package')
-app = imp.load_source('app', '/srv/workload')
-
 with open('/dev/ttyS1', 'r') as tty:
     # signal firerunner we are ready
     call('outl 126 0x3f0', shell=True)
+
+    sys.path.append('/srv/package')
+    app = imp.load_source('app', '/srv/workload')
+
     while True:
         request = json.loads(tty.readline())
 


### PR DESCRIPTION
1. put importing app source code after sending ready signal
2. open `/dev/ttyS1` in write mode inside wrapper scripts instead of redirecting stdout of `/bin/runtime-workload` to `/dev/ttyS1` in `/bin/workload`
3. fix nodejs snapshotting signal. The `for` loop should start with ` i=1`
4. set firerunner to use `console=none` by default.